### PR TITLE
Refactor AI client to async provider pattern with strategy architecture

### DIFF
--- a/backend/agents/debater_agent.py
+++ b/backend/agents/debater_agent.py
@@ -207,7 +207,7 @@ class DebaterAgent(BaseAgent):
         ]
         
         try:
-            response = self.ai_client.get_completion(messages, temperature=self.temperature)
+            response = await self.ai_client.get_completion(messages, temperature=self.temperature)
             analysis = self._parse_json_response(response, {
                 "opponent_weaknesses": [],
                 "selected_strategy": "direct_refute",
@@ -262,8 +262,8 @@ class DebaterAgent(BaseAgent):
         ]
         
         try:
-            response = self.ai_client.get_completion(messages, temperature=self.temperature)
-            
+            response = await self.ai_client.get_completion(messages, temperature=self.temperature)
+
             # 清理响应
             response = response.strip()
             if response.startswith("```"):
@@ -349,7 +349,7 @@ class DebaterAgent(BaseAgent):
         
         full_response = ""
         try:
-            for chunk in self.ai_client.chat_stream(messages, temperature=self.temperature):
+            async for chunk in self.ai_client.chat_stream(messages, temperature=self.temperature):
                 full_response += chunk
                 yield {
                     "type": "argument",

--- a/backend/agents/jury_agent.py
+++ b/backend/agents/jury_agent.py
@@ -260,7 +260,7 @@ class JuryAgent(BaseAgent):
         ]
         
         try:
-            response = self.ai_client.get_completion(messages, temperature=self.temperature)
+            response = await self.ai_client.get_completion(messages, temperature=self.temperature)
             result = self._parse_json_response(response, {
                 "pro_score": {"logic": 5, "evidence": 5, "rhetoric": 5, "rebuttal": 5},
                 "con_score": {"logic": 5, "evidence": 5, "rhetoric": 5, "rebuttal": 5},
@@ -345,7 +345,7 @@ class JuryAgent(BaseAgent):
         ]
         
         try:
-            response = self.ai_client.get_completion(messages, temperature=self.temperature)
+            response = await self.ai_client.get_completion(messages, temperature=self.temperature)
             result = self._parse_json_response(response, {})
             
             # 计算总分

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -9,7 +9,7 @@
 """
 
 from typing import Dict, Any, List, Optional, AsyncGenerator
-from .base_agent import BaseAgent, ThinkResult
+from .base_agent import ThinkResult
 from .debater_agent import DebaterAgent
 from .jury_agent import JuryAgent, RoundEvaluation, FinalVerdict
 from .protocol import MessageBus, MessageTemplates, MessageType, AgentMessage
@@ -23,54 +23,55 @@ import asyncio
 
 logger = get_logger(__name__)
 
-class DebateOrchestrator(BaseAgent):
+
+class DebateOrchestrator:
     """辩论协调器
-    
+
     状态机：
     not_started -> ready -> in_progress -> completed
-    
+
     协调流程：
     1. 初始化 Agent
     2. 开场发言
     3. 多轮辩论（正方→反方→评分）
     4. 最终裁决
     """
-    
-    # 状态定义
+
     STATE_NOT_STARTED = "not_started"
     STATE_READY = "ready"
     STATE_IN_PROGRESS = "in_progress"
     STATE_COMPLETED = "completed"
-    
+
     def __init__(self, ai_client):
-        """初始化协调器
-        
-        Args:
-            ai_client: AI 客户端实例
-        """
-        super().__init__(name="主持人", role="orchestrator", ai_client=ai_client)
-        
+        self.ai_client = ai_client
+        self.memory: List[Dict[str, Any]] = []
+
         # Agent 引用
         self.pro_agent: Optional[DebaterAgent] = None
         self.con_agent: Optional[DebaterAgent] = None
         self.jury_agent: Optional[JuryAgent] = None
-        
+
         # 共享记忆
         self.memory_store: Optional[DebateMemory] = None
-        
+
         # 消息总线
         self.message_bus = MessageBus()
-        
+
         # 状态
         self.debate_state = self.STATE_NOT_STARTED
         self.topic = ""
         self.total_rounds = 3
         self.current_round = 0
         self.run_config: Dict[str, Any] = {}
-    
+
+    def add_to_memory(self, event: Dict[str, Any]) -> None:
+        from datetime import datetime
+        event["timestamp"] = datetime.now().isoformat()
+        self.memory.append(event)
+
     async def setup_debate(
-        self, 
-        topic: str, 
+        self,
+        topic: str,
         total_rounds: int = 3,
         provider: str = "deepseek",
         model: str = "deepseek-chat",
@@ -78,19 +79,9 @@ class DebateOrchestrator(BaseAgent):
         seed: Optional[int] = None,
         preset: Optional[str] = None,
         pro_ai_client=None,
-        con_ai_client=None
+        con_ai_client=None,
     ) -> Dict[str, Any]:
-        """初始化辩论
-        
-        Args:
-            topic: 辩论主题
-            total_rounds: 总轮次
-            provider: AI 提供商
-            model: 模型名称
-            
-        Returns:
-            初始化状态
-        """
+        """初始化辩论"""
         self.topic = topic
 
         preset_config = RUN_CONFIG_PRESETS.get(preset, {}) if preset else {}
@@ -103,7 +94,6 @@ class DebateOrchestrator(BaseAgent):
             total_rounds = min(total_rounds, max_rounds)
         self.total_rounds = total_rounds
 
-        # 确定是否为混合模型模式
         is_mixed = pro_ai_client is not None or con_ai_client is not None
 
         self.run_config = {
@@ -116,7 +106,6 @@ class DebateOrchestrator(BaseAgent):
             "mixed_model": is_mixed,
         }
 
-        # 记录混合模型信息
         if pro_ai_client is not None:
             self.run_config["pro_provider"] = getattr(pro_ai_client, "provider", "unknown")
             self.run_config["pro_model"] = getattr(pro_ai_client, "model", "unknown")
@@ -126,61 +115,34 @@ class DebateOrchestrator(BaseAgent):
 
         if hasattr(self.ai_client, "seed"):
             self.ai_client.seed = seed
-        
+
         # 创建共享记忆
         self.memory_store = DebateMemory(topic=topic, total_rounds=total_rounds)
         self.memory_store.set_run_config(self.run_config)
-        
-        # 创建辩论者 Agent（支持混合模型）
+
         pro_client = pro_ai_client or self.ai_client
         con_client = con_ai_client or self.ai_client
 
-        self.pro_agent = DebaterAgent(
-            name="正方",
-            position="pro",
-            ai_client=pro_client,
-            topic=topic,
-            temperature=temperature
-        )
-        
-        self.con_agent = DebaterAgent(
-            name="反方",
-            position="con",
-            ai_client=con_client,
-            topic=topic,
-            temperature=temperature
-        )
-        
-        # 创建评审 Agent
-        self.jury_agent = JuryAgent(
-            ai_client=self.ai_client,
-            topic=topic,
-            temperature=max(0.1, temperature - 0.2)
-        )
-        
-        # 注册 Agent 到消息总线
+        self.pro_agent = DebaterAgent(name="正方", position="pro", ai_client=pro_client, topic=topic, temperature=temperature)
+        self.con_agent = DebaterAgent(name="反方", position="con", ai_client=con_client, topic=topic, temperature=temperature)
+        self.jury_agent = JuryAgent(ai_client=self.ai_client, topic=topic, temperature=max(0.1, temperature - 0.2))
+
+        # 注册到消息总线
         self.message_bus.subscribe("pro", lambda msg: logger.debug("[MessageBus] 正方收到: %s", msg.message_type.value))
         self.message_bus.subscribe("con", lambda msg: logger.debug("[MessageBus] 反方收到: %s", msg.message_type.value))
         self.message_bus.subscribe("jury", lambda msg: logger.debug("[MessageBus] 评审收到: %s", msg.message_type.value))
         self.message_bus.subscribe("orchestrator", lambda msg: logger.debug("[MessageBus] 主持人收到: %s", msg.message_type.value))
-        
-        # 发布辩论设置消息
+
         setup_msg = MessageTemplates.status(
             sender="orchestrator",
             status="debate_setup",
-            details={"topic": topic, "rounds": total_rounds, "run_config": self.run_config}
+            details={"topic": topic, "rounds": total_rounds, "run_config": self.run_config},
         )
         self.message_bus.publish(setup_msg)
-        
+
         self.debate_state = self.STATE_READY
-        
-        self.add_to_memory({
-            "type": "setup",
-            "topic": topic,
-            "total_rounds": total_rounds,
-            "agents": ["pro", "con", "jury"]
-        })
-        
+        self.add_to_memory({"type": "setup", "topic": topic, "total_rounds": total_rounds, "agents": ["pro", "con", "jury"]})
+
         return {
             "status": "ready",
             "topic": topic,
@@ -188,283 +150,43 @@ class DebateOrchestrator(BaseAgent):
             "agents": {
                 "pro": self.pro_agent.get_stats(),
                 "con": self.con_agent.get_stats(),
-                "jury": "评审就位"
+                "jury": "评审就位",
             },
-            "run_config": self.run_config
+            "run_config": self.run_config,
         }
-    
-    async def think(self, context: Dict[str, Any]) -> ThinkResult:
-        """协调器的思考 - 决定下一步行动"""
-        current_phase = context.get("phase", "unknown")
-        
-        return ThinkResult(
-            reasoning=f"当前阶段: {current_phase}, 状态: {self.debate_state}",
-            analysis={"phase": current_phase, "state": self.debate_state},
-            next_action="coordinate",
-            confidence=0.9
-        )
-    
-    async def act(self, think_result: ThinkResult) -> str:
-        """协调器的行动 - 执行协调"""
-        return "协调辩论流程"
-    
-    async def run_debate(self) -> AsyncGenerator[Dict[str, Any], None]:
-        """运行完整辩论（异步生成器）
-        
-        Yields:
-            各种事件，包括：
-            - type: opening/round_start/thinking/argument/evaluation/verdict/complete
+
+    async def run_debate_streaming(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """流式运行辩论（SSE 响应的主入口）
+
+        Yields 事件类型：
+        - opening / round_start / thinking / argument / argument_complete
+        - evaluation / standings / verdict / complete
         """
-        logger.debug("run_debate started, state=%s", self.debate_state)
-        
         if self.debate_state != self.STATE_READY:
-            logger.debug("辩论未就绪, 当前状态: %s", self.debate_state)
             yield {"type": "error", "message": "辩论未就绪，请先调用 setup_debate"}
             return
-        
+
         self.debate_state = self.STATE_IN_PROGRESS
         self.memory_store.start_debate()
-        
-        logger.debug("开始辩论，主题: %s", self.topic)
-        
-        # 开场
-        yield {
-            "type": "opening",
-            "content": f"欢迎来到本场辩论！今天的辩题是：**{self.topic}**",
-            "topic": self.topic,
-            "total_rounds": self.total_rounds
-        }
-        
-        # 辩论上下文
-        debate_context = {
-            "topic": self.topic,
-            "history": []
-        }
-        
-        # 进行多轮辩论
+
+        yield {"type": "opening", "content": f"辩题：{self.topic}", "topic": self.topic, "total_rounds": self.total_rounds}
+
+        debate_context: Dict[str, Any] = {"topic": self.topic, "history": []}
+
         for round_num in range(1, self.total_rounds + 1):
             self.current_round = round_num
             self.memory_store.start_round(round_num)
-            
-            # 轮次开始
-            yield {
-                "type": "round_start",
-                "round": round_num,
-                "total_rounds": self.total_rounds
-            }
-            
-            # === 正方发言 ===
-            pro_context = {
-                "round": round_num,
-                "is_opening": round_num == 1 and len(debate_context["history"]) == 0,
-                "opponent_last_argument": debate_context["history"][-1]["content"] if debate_context["history"] else "",
-                "history": debate_context["history"]
-            }
-            
-            logger.debug("第%s轮 - 正方开始思考...", round_num)
-            
-            # 正方思考
-            pro_think, pro_argument = await self.pro_agent.react(pro_context)
-            logger.debug("正方思考完成，论点长度: %s", len(pro_argument))
-            
-            yield {
-                "type": "thinking",
-                "round": round_num,
-                "side": "pro",
-                "name": "正方",
-                "content": pro_think.analysis,
-                "confidence": pro_think.confidence
-            }
-            
-            yield {
-                "type": "argument",
-                "round": round_num,
-                "side": "pro",
-                "name": "正方",
-                "content": pro_argument
-            }
-            
-            # 记录到共享记忆
-            self.memory_store.add_argument(
-                side="pro",
-                agent_name="正方",
-                content=pro_argument,
-                thinking=pro_think.analysis
-            )
-            
-            # 发布正方论点消息到消息总线
-            pro_msg = MessageTemplates.argument(sender="pro", content=pro_argument, round=round_num)
-            self.message_bus.publish(pro_msg)
-            
-            debate_context["history"].append({
-                "round": round_num,
-                "side": "pro",
-                "content": pro_argument
-            })
-            
-            # === 反方发言 ===
-            con_context = {
-                "round": round_num,
-                "is_opening": round_num == 1,  # 第一轮双方都做开场发言，确保公平
-                "opponent_last_argument": pro_argument,
-                "history": debate_context["history"]
-            }
-            
-            # 反方思考
-            con_think, con_argument = await self.con_agent.react(con_context)
-            
-            yield {
-                "type": "thinking",
-                "round": round_num,
-                "side": "con",
-                "name": "反方",
-                "content": con_think.analysis,
-                "confidence": con_think.confidence
-            }
-            
-            yield {
-                "type": "argument",
-                "round": round_num,
-                "side": "con",
-                "name": "反方",
-                "content": con_argument
-            }
-            
-            # 记录到共享记忆
-            self.memory_store.add_argument(
-                side="con",
-                agent_name="反方",
-                content=con_argument,
-                thinking=con_think.analysis
-            )
-            
-            # 发布反方论点消息到消息总线
-            con_msg = MessageTemplates.argument(sender="con", content=con_argument, round=round_num)
-            self.message_bus.publish(con_msg)
-            
-            debate_context["history"].append({
-                "round": round_num,
-                "side": "con",
-                "content": con_argument
-            })
-            
-            # === 评审评分 ===
-            evaluation = await self.jury_agent.evaluate_round(
-                pro_argument=pro_argument,
-                con_argument=con_argument,
-                round_num=round_num,
-                history=[e for e in self.memory_store.evaluations]
-            )
-            
-            eval_dict = evaluation.model_dump()
-            self.memory_store.add_evaluation(eval_dict)
-            
-            # 发布评审消息到消息总线
-            eval_msg = MessageTemplates.evaluation(
-                sender="jury",
-                receiver="",  # 广播
-                scores={"pro": eval_dict["pro_score"], "con": eval_dict["con_score"]},
-                commentary=evaluation.commentary,
-                round=round_num
-            )
-            self.message_bus.publish(eval_msg)
-            
-            yield {
-                "type": "evaluation",
-                "round": round_num,
-                "pro_score": eval_dict["pro_score"],
-                "con_score": eval_dict["con_score"],
-                "round_winner": evaluation.round_winner,
-                "commentary": evaluation.commentary,
-                "highlights": evaluation.highlights,
-                "suggestions": evaluation.suggestions
-            }
-            
-            self.memory_store.end_round(round_num)
-            
-            # 实时比分
-            yield {
-                "type": "standings",
-                "round": round_num,
-                "standings": self.memory_store.get_current_standings()
-            }
-        
-        # === 最终裁决 ===
-        verdict = await self.jury_agent.final_verdict()
-        verdict_dict = verdict.model_dump()
-        
-        self.memory_store.set("verdict", verdict_dict)
-        self.memory_store.complete_debate(verdict_dict)
-        
-        # 发布裁决消息到消息总线
-        verdict_msg = MessageTemplates.verdict(
-            sender="jury",
-            winner=verdict.winner,
-            pro_score=verdict.pro_total_score,
-            con_score=verdict.con_total_score,
-            summary=verdict.summary
-        )
-        self.message_bus.publish(verdict_msg)
-        
-        yield {
-            "type": "verdict",
-            "winner": verdict.winner,
-            "pro_total_score": verdict.pro_total_score,
-            "con_total_score": verdict.con_total_score,
-            "margin": verdict.margin,
-            "summary": verdict.summary,
-            "pro_strengths": verdict.pro_strengths,
-            "con_strengths": verdict.con_strengths,
-            "key_turning_points": verdict.key_turning_points
-        }
-        
-        self.debate_state = self.STATE_COMPLETED
-        
-        # 完成
-        yield {
-            "type": "complete",
-            "message": "辩论结束",
-            "final_state": self.memory_store.get_full_state(),
-            "message_history": self.message_bus.export_history()  # 导出消息历史
-        }
-    
-    async def run_debate_streaming(self) -> AsyncGenerator[Dict[str, Any], None]:
-        """流式运行辩论（带流式论点输出）
-        
-        适用于 SSE 流式响应
-        """
-        if self.debate_state != self.STATE_READY:
-            yield {"type": "error", "message": "辩论未就绪"}
-            return
-        
-        self.debate_state = self.STATE_IN_PROGRESS
-        self.memory_store.start_debate()
-        
-        # 开场
-        yield {
-            "type": "opening",
-            "content": f"辩题：{self.topic}",
-            "topic": self.topic,
-            "total_rounds": self.total_rounds
-        }
-        
-        debate_context = {"topic": self.topic, "history": []}
-        
-        for round_num in range(1, self.total_rounds + 1):
-            self.current_round = round_num
-            self.memory_store.start_round(round_num)
-            
-            yield {"type": "round_start", "round": round_num}
-            
-            # 正方上下文
+
+            yield {"type": "round_start", "round": round_num, "total_rounds": self.total_rounds}
+
+            # === 正方 ===
             pro_context = {
                 "round": round_num,
                 "is_opening": round_num == 1,
                 "opponent_last_argument": debate_context["history"][-1]["content"] if debate_context["history"] else "",
-                "history": debate_context["history"]
+                "history": debate_context["history"],
             }
-            
-            # 正方流式输出
+
             pro_full_argument = ""
             pro_thinking = None
             async for event in self._stream_agent_react(self.pro_agent, pro_context):
@@ -473,21 +195,20 @@ class DebateOrchestrator(BaseAgent):
                 yield event
                 if event.get("type") == "argument_complete":
                     pro_full_argument = event.get("content", "")
-            
+
             self.memory_store.add_argument("pro", "正方", pro_full_argument, thinking=pro_thinking)
-            debate_context["history"].append({
-                "round": round_num, "side": "pro", "content": pro_full_argument
-            })
-            
-            # 反方上下文
+            pro_msg = MessageTemplates.argument(sender="pro", content=pro_full_argument, round=round_num)
+            self.message_bus.publish(pro_msg)
+            debate_context["history"].append({"round": round_num, "side": "pro", "content": pro_full_argument})
+
+            # === 反方 ===
             con_context = {
                 "round": round_num,
-                "is_opening": round_num == 1,  # 第一轮双方都做开场发言
+                "is_opening": round_num == 1,
                 "opponent_last_argument": pro_full_argument,
-                "history": debate_context["history"]
+                "history": debate_context["history"],
             }
-            
-            # 反方流式输出
+
             con_full_argument = ""
             con_thinking = None
             async for event in self._stream_agent_react(self.con_agent, con_context):
@@ -496,60 +217,62 @@ class DebateOrchestrator(BaseAgent):
                 yield event
                 if event.get("type") == "argument_complete":
                     con_full_argument = event.get("content", "")
-            
+
             self.memory_store.add_argument("con", "反方", con_full_argument, thinking=con_thinking)
-            debate_context["history"].append({
-                "round": round_num, "side": "con", "content": con_full_argument
-            })
-            
-            # 评审
-            evaluation = await self.jury_agent.evaluate_round(
-                pro_full_argument, con_full_argument, round_num
-            )
+            con_msg = MessageTemplates.argument(sender="con", content=con_full_argument, round=round_num)
+            self.message_bus.publish(con_msg)
+            debate_context["history"].append({"round": round_num, "side": "con", "content": con_full_argument})
+
+            # === 评审 ===
+            evaluation = await self.jury_agent.evaluate_round(pro_full_argument, con_full_argument, round_num)
             eval_dict = evaluation.model_dump()
             self.memory_store.add_evaluation(eval_dict)
-            
-            yield {
-                "type": "evaluation",
-                "round": round_num,
-                **eval_dict
-            }
-            
-            yield {
-                "type": "standings",
-                "standings": self.memory_store.get_current_standings()
-            }
-        
-        # 最终裁决
+
+            eval_msg = MessageTemplates.evaluation(
+                sender="jury",
+                receiver="",
+                scores={"pro": eval_dict["pro_score"], "con": eval_dict["con_score"]},
+                commentary=evaluation.commentary,
+                round=round_num,
+            )
+            self.message_bus.publish(eval_msg)
+
+            yield {"type": "evaluation", "round": round_num, **eval_dict}
+            yield {"type": "standings", "standings": self.memory_store.get_current_standings()}
+
+            self.memory_store.end_round(round_num)
+
+        # === 最终裁决 ===
         verdict = await self.jury_agent.final_verdict()
         verdict_dict = verdict.model_dump()
         self.memory_store.set("verdict", verdict_dict)
         self.memory_store.complete_debate(verdict_dict)
-        
+
+        verdict_msg = MessageTemplates.verdict(
+            sender="jury",
+            winner=verdict.winner,
+            pro_score=verdict.pro_total_score,
+            con_score=verdict.con_total_score,
+            summary=verdict.summary,
+        )
+        self.message_bus.publish(verdict_msg)
+
         yield {"type": "verdict", **verdict_dict}
-        
+
         self.debate_state = self.STATE_COMPLETED
-        yield {"type": "complete"}
-    
+        yield {"type": "complete", "message_history": self.message_bus.export_history()}
+
     async def _stream_agent_react(
-        self, 
-        agent: DebaterAgent, 
-        context: Dict[str, Any]
+        self,
+        agent: DebaterAgent,
+        context: Dict[str, Any],
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """流式执行 Agent ReAct"""
-        # stream_react 已经是异步生成器，直接使用 async for
         async for event in agent.stream_react(context):
             event["round"] = context.get("round", 1)
             yield event
-    
-    async def _async_wrapper(self, sync_generator):
-        """将同步生成器包装为异步生成器（保留以备其他用途）"""
-        for item in sync_generator:
-            yield item
-            await asyncio.sleep(0)  # 让出控制权
-    
+
     def get_debate_state(self) -> Dict[str, Any]:
-        """获取当前辩论状态"""
         return {
             "state": self.debate_state,
             "topic": self.topic,
@@ -559,23 +282,16 @@ class DebateOrchestrator(BaseAgent):
             "agents": {
                 "pro": self.pro_agent.get_stats() if self.pro_agent else None,
                 "con": self.con_agent.get_stats() if self.con_agent else None,
-            }
+            },
         }
-    
+
     def get_transcript(self) -> str:
-        """获取辩论记录"""
-        if self.memory_store:
-            return self.memory_store.export_transcript()
-        return ""
-    
+        return self.memory_store.export_transcript() if self.memory_store else ""
+
     def get_full_state(self) -> Dict[str, Any]:
-        """获取完整状态"""
-        if self.memory_store:
-            return self.memory_store.get_full_state()
-        return {}
+        return self.memory_store.get_full_state() if self.memory_store else {}
 
     def build_trace(self) -> Dict[str, Any]:
-        """构建辩论 Trace"""
         if not self.memory_store:
             return {}
 
@@ -586,8 +302,7 @@ class DebateOrchestrator(BaseAgent):
             eval_ = next((e for e in evaluations if e.get("round") == round_num), None)
             if not eval_:
                 return None
-            side_key = f"{side}_score"
-            score = eval_.get(side_key)
+            score = eval_.get(f"{side}_score")
             if isinstance(score, dict):
                 total = sum(score.values())
                 return {**score, "total": total}
@@ -603,10 +318,9 @@ class DebateOrchestrator(BaseAgent):
                 "action": "argument",
                 "result": arg.content,
                 "score": score_for_round(arg.round, arg.side),
-                "timestamp": arg.timestamp.isoformat()
+                "timestamp": arg.timestamp.isoformat(),
             })
 
-        # 估算成本
         texts = [a.content for a in self.memory_store.arguments]
         for eval_ in evaluations:
             if eval_.get("commentary"):
@@ -626,7 +340,5 @@ class DebateOrchestrator(BaseAgent):
             "verdict": verdict,
             "standings": self.memory_store.get_current_standings(),
             "cost": cost,
-            "message_history": self.message_bus.export_history()
+            "message_history": self.message_bus.export_history(),
         }
-
-

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -98,7 +98,7 @@ async def chat(request: ChatRequest, db: DBSession = Depends(get_db)):
         messages = build_chat_messages(request.message, request.history)
 
         # 获取回复
-        response_content = client.get_completion(messages)
+        response_content = await client.get_completion(messages)
 
         # 创建或更新会话
         session = _get_or_create_chat_session(
@@ -133,9 +133,9 @@ async def chat(request: ChatRequest, db: DBSession = Depends(get_db)):
 
 
 @router.get("/chat/stream")
-def stream_chat(
+async def stream_chat(
     message: str,
-    history: str = "[]",  # JSON字符串
+    history: str = "[]",
     provider: str = "deepseek",
     model: str = "deepseek-chat",
     session_id: Optional[int] = None,
@@ -143,16 +143,14 @@ def stream_chat(
 ):
     """流式对话接口"""
 
-    def generate():
+    async def generate():
         try:
             api_key = get_api_key(provider)
             client = AIClient(provider=provider, model=model, api_key=api_key)
 
-            # 解析历史消息
             history_list = _parse_history(history)
             messages = build_chat_messages(message, history_list)
 
-            # 创建或复用会话
             session = _get_or_create_chat_session(
                 db=db,
                 session_id=session_id,
@@ -161,21 +159,17 @@ def stream_chat(
                 model=model,
             )
 
-            # 发送会话ID
             yield sse_event({"type": "session", "session_id": session.id})
 
-            # 保存用户消息
             user_msg = Message(session_id=session.id, role="user", content=message)
             db.add(user_msg)
             db.commit()
 
-            # 流式生成回复
             full_response = ""
-            for chunk in client.chat_stream(messages):
+            async for chunk in client.chat_stream(messages):
                 full_response += chunk
                 yield sse_event({"type": "content", "content": full_response})
 
-            # 保存助手消息
             assistant_msg = Message(session_id=session.id, role="assistant", content=full_response)
             db.add(assistant_msg)
             db.commit()
@@ -215,7 +209,7 @@ def get_available_roles():
 
 
 @router.get("/chat/dual-stream")
-def stream_dual_chat(
+async def stream_dual_chat(
     topic: str,
     role_a: str = "乐观主义者",
     role_b: str = "现实主义者",
@@ -229,14 +223,6 @@ def stream_dual_chat(
 
     两个 AI 角色围绕主题进行自然对话。
 
-    Args:
-        topic: 对话主题
-        role_a: 角色A模板名称
-        role_b: 角色B模板名称
-        turns: 对话轮次
-        provider: AI 提供商
-        model: 模型
-
     Returns:
         SSE 事件流，包含：
         - start: 对话开始，包含角色信息
@@ -244,20 +230,18 @@ def stream_dual_chat(
         - message_complete: 消息生成完成
         - complete: 对话结束
     """
-    def generate():
+    async def generate():
         try:
             api_key = get_api_key(provider)
             client = AIClient(provider=provider, model=model, api_key=api_key)
 
-            # 创建双角色对话服务
             dual_chat = create_dual_chat(
                 ai_client=client,
                 topic=topic,
                 role_a_template=role_a,
-                role_b_template=role_b
+                role_b_template=role_b,
             )
 
-            # 创建会话
             session = Session(
                 session_type="dual_chat",
                 topic=topic,
@@ -267,8 +251,8 @@ def stream_dual_chat(
                     "role_a": role_a,
                     "role_b": role_b,
                     "turns": turns,
-                    "mode": "dual_character"
-                }
+                    "mode": "dual_character",
+                },
             )
             db.add(session)
             db.commit()
@@ -276,11 +260,9 @@ def stream_dual_chat(
 
             yield sse_event({"type": "session", "session_id": session.id})
 
-            # 运行对话
-            for event in dual_chat.run_conversation(turns=turns):
+            async for event in dual_chat.run_conversation(turns=turns):
                 yield sse_event(event, ensure_ascii=False)
 
-                # 保存消息到数据库
                 if event.get("type") == "message_complete":
                     msg = Message(
                         session_id=session.id,
@@ -289,8 +271,8 @@ def stream_dual_chat(
                         meta_info={
                             "role_id": event.get("role_id"),
                             "turn": event.get("turn"),
-                            "mode": "dual_character"
-                        }
+                            "mode": "dual_character",
+                        },
                     )
                     db.add(msg)
 

--- a/backend/routers/debate/agent.py
+++ b/backend/routers/debate/agent.py
@@ -257,13 +257,13 @@ async def agent_debate(
         settings["preset"] = orchestrator.run_config.get("preset")
         session.settings = settings
         
-        # 收集所有事件
+        # 收集所有事件（复用流式接口）
         events = []
-        async for event in orchestrator.run_debate():
+        async for event in orchestrator.run_debate_streaming():
             events.append(event)
-            
-            # 保存论点消息
-            if event.get("type") == "argument":
+
+            # 保存完整论点消息
+            if event.get("type") == "argument_complete":
                 message = Message(
                     session_id=session.id,
                     role=event.get("name", event.get("side")),
@@ -271,8 +271,8 @@ async def agent_debate(
                     meta_info={
                         "round": event.get("round"),
                         "side": event.get("side"),
-                        "mode": "multi-agent"
-                    }
+                        "mode": "multi-agent",
+                    },
                 )
                 db.add(message)
         
@@ -282,7 +282,7 @@ async def agent_debate(
         db.commit()
         
         # 提取关键信息
-        arguments = [e for e in events if e.get("type") == "argument"]
+        arguments = [e for e in events if e.get("type") == "argument_complete"]
         thinkings = [e for e in events if e.get("type") == "thinking"]
         evaluations = [e for e in events if e.get("type") == "evaluation"]
         verdict = next((e for e in events if e.get("type") == "verdict"), None)

--- a/backend/routers/qa.py
+++ b/backend/routers/qa.py
@@ -113,7 +113,7 @@ async def qa(request: QARequest, db: DBSession = Depends(get_db)):
         )
 
         # 获取回复
-        response_content = client.get_completion(messages)
+        response_content = await client.get_completion(messages)
 
         # 创建或复用会话
         session = _get_or_create_session(
@@ -147,7 +147,7 @@ async def qa(request: QARequest, db: DBSession = Depends(get_db)):
 
 
 @router.get("/qa/stream")
-def stream_qa(
+async def stream_qa(
     question: str,
     style: str = "professional",
     history: str = "[]",
@@ -158,16 +158,14 @@ def stream_qa(
 ):
     """流式问答接口"""
 
-    def generate():
+    async def generate():
         try:
             api_key = get_api_key(provider)
             client = AIClient(provider=provider, model=model, api_key=api_key)
 
-            # 解析历史消息
             history_list = _parse_history(history)
             messages = build_qa_messages(question=question, style=style, history=history_list)
 
-            # 创建或复用会话
             session = _get_or_create_session(
                 db=db,
                 session_id=session_id,
@@ -176,21 +174,17 @@ def stream_qa(
                 settings={"provider": provider, "model": model, "style": style},
             )
 
-            # 发送会话ID
             yield sse_event({"type": "session", "session_id": session.id})
 
-            # 保存用户消息
             user_msg = Message(session_id=session.id, role="user", content=question)
             db.add(user_msg)
             db.commit()
 
-            # 流式生成回复
             full_response = ""
-            for chunk in client.chat_stream(messages):
+            async for chunk in client.chat_stream(messages):
                 full_response += chunk
                 yield sse_event({"type": "content", "content": full_response})
 
-            # 保存助手消息
             assistant_msg = Message(session_id=session.id, role="assistant", content=full_response)
             db.add(assistant_msg)
             db.commit()
@@ -264,7 +258,7 @@ async def socratic_qa(
         qa_service = create_socratic_qa(client, mode=mode)
 
         # 获取回答
-        result = qa_service.ask(question)
+        result = await qa_service.ask(question)
 
         # 创建或复用会话
         session = _get_or_create_session(
@@ -308,7 +302,7 @@ async def socratic_qa(
 
 
 @router.get("/qa/socratic-stream")
-def stream_socratic_qa(
+async def stream_socratic_qa(
     question: str,
     mode: str = "hybrid",
     history: str = "[]",
@@ -322,23 +316,20 @@ def stream_socratic_qa(
 
     流式返回引导式或结构化回答。
     """
-    def generate():
+    async def generate():
         try:
             api_key = get_api_key(provider)
             client = AIClient(provider=provider, model=model, api_key=api_key)
 
-            # 创建服务
             qa_service = create_socratic_qa(client, mode=mode)
 
-            # 恢复历史（如果有）
             history_list = _parse_history(history)
             for msg in history_list:
                 qa_service.conversation_history.append({
                     "role": msg.get("role", "user"),
-                    "content": msg.get("content", "")
+                    "content": msg.get("content", ""),
                 })
 
-            # 创建或复用会话
             session = _get_or_create_session(
                 db=db,
                 session_id=session_id,
@@ -349,25 +340,22 @@ def stream_socratic_qa(
 
             yield sse_event({"type": "session", "session_id": session.id, "mode": mode})
 
-            # 保存用户消息
             user_msg = Message(session_id=session.id, role="user", content=question)
             db.add(user_msg)
             db.commit()
 
-            # 流式生成
             full_response = ""
-            for event in qa_service.stream_ask(question):
+            async for event in qa_service.stream_ask(question):
                 yield sse_event(event, ensure_ascii=False)
                 if event.get("type") == "complete":
                     full_response = event.get("content", "")
 
-            # 保存回复
             if full_response:
                 assistant_msg = Message(
                     session_id=session.id,
                     role="assistant",
                     content=full_response,
-                    meta_info={"mode": mode}
+                    meta_info={"mode": mode},
                 )
                 db.add(assistant_msg)
                 db.commit()
@@ -419,7 +407,7 @@ async def qa_follow_up(
             })
 
         # 处理用户回复
-        result = qa_service.follow_up(response)
+        result = await qa_service.follow_up(response)
 
         # 保存消息
         user_msg = Message(session_id=session_id, role="user", content=response)

--- a/backend/services/ai_client.py
+++ b/backend/services/ai_client.py
@@ -1,342 +1,67 @@
 """
-AI客户端封装 - 支持多提供商
+AI 客户端封装 - 支持多提供商
 
-提供统一的 AI 调用接口，支持连接池复用
+统一的 AI 调用入口，通过 Provider 策略模式支持：
+- DeepSeek / OpenAI（OpenAI 兼容接口）
+- Google Gemini
+- Anthropic Claude
+- Mock（测试用）
+
+所有 IO 操作均为异步，避免阻塞 FastAPI 事件循环。
 """
-from openai import OpenAI
-from typing import Generator, Optional, Dict
-import os
-import sys
-import httpx
-import json
-import hashlib
-import random
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from config import get_settings
+from typing import AsyncGenerator, Optional
+
+from services.providers import BaseProvider, create_provider
 
 
 class AIClient:
-    """统一的AI客户端封装，支持 DeepSeek, OpenAI, Gemini, Claude, Mock
-    
-    特性：
-    - 连接池复用：相同配置的客户端将被复用
-    - 超时配置：合理的超时设置
-    - 多提供商支持：DeepSeek、OpenAI、Gemini、Claude
+    """统一的 AI 客户端，委托给具体 Provider 实现。
+
+    用法：
+        client = AIClient(provider="deepseek", model="deepseek-chat", api_key=...)
+        text = await client.get_completion(messages)
+        async for chunk in client.chat_stream(messages):
+            ...
     """
-    
-    # 类级别连接池，复用 OpenAI 客户端
-    _client_pool: Dict[str, OpenAI] = {}
-    
-    @classmethod
-    def _get_pool_key(cls, provider: str, api_key: str, base_url: str = "") -> str:
-        """生成连接池的键"""
-        return f"{provider}:{api_key[:8]}:{base_url}"
-    
-    @classmethod
-    def _get_or_create_client(
-        cls, 
-        provider: str, 
-        api_key: str, 
-        base_url: str,
-        timeout: httpx.Timeout
-    ) -> OpenAI:
-        """获取或创建 OpenAI 客户端（连接池复用）"""
-        pool_key = cls._get_pool_key(provider, api_key, base_url)
-        
-        if pool_key not in cls._client_pool:
-            cls._client_pool[pool_key] = OpenAI(
-                api_key=api_key,
-                base_url=base_url,
-                timeout=timeout
-            )
-        
-        return cls._client_pool[pool_key]
-    
+
     def __init__(
         self,
         provider: str = "deepseek",
         model: str = "deepseek-chat",
         api_key: Optional[str] = None,
-        seed: Optional[int] = None
+        seed: Optional[int] = None,
     ):
         self.provider = provider
         self.model = model
-        self.api_key = api_key
         self.seed = seed
-        
-        settings = get_settings()
-        timeout = httpx.Timeout(connect=5.0, read=60.0, write=10.0, pool=10.0)
-        
-        if provider == "deepseek":
-            final_api_key = api_key or settings.deepseek_api_key or os.getenv("DEEPSEEK_API_KEY")
-            self.client = self._get_or_create_client(
-                provider, final_api_key, settings.deepseek_api_base, timeout
-            )
-        elif provider == "openai":
-            final_api_key = api_key or settings.openai_api_key or os.getenv("OPENAI_API_KEY")
-            self.client = self._get_or_create_client(
-                provider, final_api_key, settings.openai_api_base, timeout
-            )
-        elif provider == "gemini":
-            final_api_key = api_key or settings.gemini_api_key or os.getenv("GEMINI_API_KEY")
-            self.api_key = final_api_key
-            # Gemini 使用 google-genai SDK，在调用时初始化
-            self.client = None
-        elif provider == "claude":
-            final_api_key = api_key or settings.claude_api_key or os.getenv("CLAUDE_API_KEY")
-            self.api_key = final_api_key
-            # Claude 使用 anthropic SDK，在调用时初始化
-            self.client = None
-        elif provider == "mock":
-            self.client = None
-        else:
-            raise ValueError(f"不支持的提供商: {provider}")
-    
-    def chat(
-        self, 
-        messages: list[dict], 
-        temperature: float = 0.7, 
+        self._provider: BaseProvider = create_provider(
+            provider=provider,
+            model=model,
+            api_key=api_key,
+            seed=seed,
+        )
+
+    async def get_completion(
+        self,
+        messages: list[dict],
+        temperature: float = 0.7,
         max_tokens: int = 2000,
-        stream: bool = False,
-        seed: Optional[int] = None
-    ):
-        """发送聊天请求（仅适用于OpenAI兼容的API）"""
-        if self.provider in ["gemini", "claude"]:
-            raise NotImplementedError(f"{self.provider} 不支持此方法，请使用 chat_stream 或 get_completion")
-        final_seed = self.seed if seed is None else seed
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "stream": stream
-        }
-        if final_seed is not None:
-            payload["seed"] = final_seed
-        response = self.client.chat.completions.create(**payload)
-        return response
-    
-    def chat_stream(
-        self, 
-        messages: list[dict], 
-        temperature: float = 0.7, 
-        max_tokens: int = 2000
-    ) -> Generator[str, None, None]:
-        """流式聊天请求"""
-        if self.provider in ["deepseek", "openai"]:
-            # OpenAI 兼容 API
-            stream = self.chat(messages, temperature, max_tokens, stream=True)
-            for chunk in stream:
-                if chunk.choices and len(chunk.choices) > 0:
-                    delta = chunk.choices[0].delta
-                    if hasattr(delta, 'content') and delta.content:
-                        yield delta.content
-                        
-        elif self.provider == "gemini":
-            # Google Gemini API
-            from google import genai
-            client = genai.Client(api_key=self.api_key)
-            
-            # 转换消息格式
-            contents = self._convert_messages_for_gemini(messages)
-            
-            for chunk in client.models.generate_content_stream(
-                model=self.model,
-                contents=contents
-            ):
-                if chunk.text:
-                    yield chunk.text
-                    
-        elif self.provider == "claude":
-            # Anthropic Claude API
-            import anthropic
-            client = anthropic.Anthropic(api_key=self.api_key)
-            
-            # 分离系统提示和用户消息
-            system_prompt, claude_messages = self._convert_messages_for_claude(messages)
-            
-            with client.messages.stream(
-                model=self.model,
-                max_tokens=max_tokens,
-                system=system_prompt,
-                messages=claude_messages
-            ) as stream:
-                for text in stream.text_stream:
-                    yield text
-        elif self.provider == "mock":
-            content = self._mock_response(messages, temperature=temperature)
-            for chunk in self._chunk_text(content):
-                yield chunk
-    
-    def get_completion(self, messages: list[dict], **kwargs) -> str:
+        **kwargs,
+    ) -> str:
         """获取完整回复（非流式）"""
-        if self.provider in ["deepseek", "openai"]:
-            response = self.chat(messages, stream=False, **kwargs)
-            return response.choices[0].message.content
-            
-        elif self.provider == "gemini":
-            from google import genai
-            client = genai.Client(api_key=self.api_key)
-            contents = self._convert_messages_for_gemini(messages)
-            response = client.models.generate_content(
-                model=self.model,
-                contents=contents
-            )
-            return response.text
-            
-        elif self.provider == "claude":
-            import anthropic
-            client = anthropic.Anthropic(api_key=self.api_key)
-            system_prompt, claude_messages = self._convert_messages_for_claude(messages)
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=kwargs.get("max_tokens", 2000),
-                system=system_prompt,
-                messages=claude_messages
-            )
-            return response.content[0].text
-        elif self.provider == "mock":
-            temperature = kwargs.get("temperature", 0.7)
-            return self._mock_response(messages, temperature=temperature)
-        
-        return ""
-    
-    def _convert_messages_for_gemini(self, messages: list[dict]) -> str:
-        """将消息格式转换为 Gemini 格式"""
-        # Gemini 接受简单的字符串或 Content 对象
-        # 这里简化处理，将所有消息拼接
-        parts = []
-        for msg in messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            if role == "system":
-                parts.append(f"系统指令：{content}")
-            elif role == "assistant":
-                parts.append(f"助手：{content}")
-            else:
-                parts.append(f"用户：{content}")
-        return "\n\n".join(parts)
-    
-    def _convert_messages_for_claude(self, messages: list[dict]) -> tuple[str, list[dict]]:
-        """将消息格式转换为 Claude 格式"""
-        system_prompt = ""
-        claude_messages = []
-        
-        for msg in messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
-            
-            if role == "system":
-                system_prompt = content
-            else:
-                # Claude 只接受 user 和 assistant 角色
-                claude_role = "assistant" if role == "assistant" else "user"
-                claude_messages.append({"role": claude_role, "content": content})
-        
-        return system_prompt, claude_messages
+        return await self._provider.get_completion(
+            messages, temperature=temperature, max_tokens=max_tokens, **kwargs
+        )
 
-    def _mock_response(self, messages: list[dict], temperature: float = 0.7) -> str:
-        """生成可复现的 Mock 响应"""
-        seed = self._derive_seed(messages, temperature)
-        rng = random.Random(seed)
-        prompt = messages[-1].get("content", "") if messages else ""
-        prompt_str = prompt if isinstance(prompt, str) else json.dumps(prompt, ensure_ascii=False)
-
-        if "pro_score" in prompt_str and "con_score" in prompt_str:
-            return json.dumps(self._mock_round_evaluation(rng), ensure_ascii=False)
-        if "opening_strategy" in prompt_str and "key_arguments" in prompt_str:
-            return json.dumps(self._mock_opening_analysis(rng), ensure_ascii=False)
-        if "selected_strategy" in prompt_str and "counter_points" in prompt_str:
-            return json.dumps(self._mock_counter_analysis(rng), ensure_ascii=False)
-        if "key_turning_points" in prompt_str and "winner" in prompt_str:
-            return json.dumps(self._mock_final_verdict(rng), ensure_ascii=False)
-
-        return self._mock_argument_text(rng)
-
-    def _derive_seed(self, messages: list[dict], temperature: float) -> int:
-        payload = json.dumps(messages, ensure_ascii=False, sort_keys=True)
-        seed_base = self.seed if self.seed is not None else 0
-        raw = f"{seed_base}|{temperature}|{self.model}|{payload}"
-        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
-        return int(digest[:8], 16)
-
-    def _mock_opening_analysis(self, rng: random.Random) -> Dict:
-        return {
-            "topic_analysis": "辩题涉及社会与技术变迁的边界，需要区分岗位替代与能力增强。",
-            "core_stance": "技术将改变岗位形态而非完全替代人类价值。",
-            "opening_strategy": "强调历史类比与人机协作的现实案例。",
-            "key_arguments": [
-                "技术替代的是任务而非整体职业",
-                "协作模式会创造新岗位需求",
-                "制度与教育会同步调整"
-            ],
-            "anticipated_opposition": [
-                "自动化会导致大规模失业",
-                "AI 成本低于人力"
-            ],
-            "confidence": round(rng.uniform(0.6, 0.85), 2)
-        }
-
-    def _mock_counter_analysis(self, rng: random.Random) -> Dict:
-        return {
-            "opponent_main_points": ["对方强调成本优势与效率提升"],
-            "opponent_weaknesses": ["忽视再就业与产业结构调整的时间窗"],
-            "selected_strategy": rng.choice(["direct_refute", "reframe", "counter_example"]),
-            "strategy_reason": "选择可直接削弱对方核心假设的策略。",
-            "counter_points": ["效率提升不等同于岗位消失", "历史上技术升级带来新需求"],
-            "new_arguments": ["政策与教育可缓冲冲击"],
-            "confidence": round(rng.uniform(0.55, 0.8), 2)
-        }
-
-    def _mock_round_evaluation(self, rng: random.Random) -> Dict:
-        def score():
-            return {
-                "logic": rng.randint(5, 9),
-                "evidence": rng.randint(5, 9),
-                "rhetoric": rng.randint(5, 9),
-                "rebuttal": rng.randint(5, 9)
-            }
-
-        pro_score = score()
-        con_score = score()
-        pro_total = sum(pro_score.values())
-        con_total = sum(con_score.values())
-        winner = "pro" if pro_total > con_total else ("con" if con_total > pro_total else "tie")
-
-        return {
-            "pro_score": pro_score,
-            "con_score": con_score,
-            "round_winner": winner,
-            "commentary": "双方论点清晰，正方在结构性分析上略胜一筹。",
-            "highlights": ["结构化论证", "反驳切中要点"],
-            "suggestions": {
-                "pro": ["补充更多现实案例支撑论点"],
-                "con": ["加强对反例的处理"]
-            }
-        }
-
-    def _mock_final_verdict(self, rng: random.Random) -> Dict:
-        winner = rng.choice(["pro", "con", "tie"])
-        return {
-            "winner": winner,
-            "pro_total_score": rng.randint(60, 75),
-            "con_total_score": rng.randint(58, 74),
-            "margin": rng.choice(["decisive", "close", "marginal"]),
-            "summary": "整体而言，双方论证充分，胜负取决于对关键假设的把握。",
-            "pro_strengths": ["逻辑连贯", "结构完整"],
-            "con_strengths": ["反驳直接", "案例贴近现实"],
-            "key_turning_points": ["第二轮反驳质量差异", "总结陈词的结构性优势"]
-        }
-
-    def _mock_argument_text(self, rng: random.Random) -> str:
-        templates = [
-            "我们需要区分任务替代与职业替代。技术会提升效率，但更重要的是重构分工。",
-            "历史上每次技术革命都会淘汰部分岗位，但也会催生新的价值链。",
-            "关键不在于是否替代，而在于社会如何调整制度与教育以吸收冲击。"
-        ]
-        rng.shuffle(templates)
-        return " ".join(templates)
-
-    def _chunk_text(self, text: str, chunk_size: int = 24):
-        for i in range(0, len(text), chunk_size):
-            yield text[i:i + chunk_size]
+    async def chat_stream(
+        self,
+        messages: list[dict],
+        temperature: float = 0.7,
+        max_tokens: int = 2000,
+        **kwargs,
+    ) -> AsyncGenerator[str, None]:
+        """流式获取回复（异步生成器）"""
+        async for chunk in self._provider.chat_stream(
+            messages, temperature=temperature, max_tokens=max_tokens, **kwargs
+        ):
+            yield chunk

--- a/backend/services/dual_chat.py
+++ b/backend/services/dual_chat.py
@@ -4,19 +4,18 @@
 两个 AI 角色基于主题进行自然对话，用户作为旁观者。
 """
 
-from typing import Dict, Any, List, Optional, Generator
+from typing import AsyncGenerator, Dict, List, Optional
 from dataclasses import dataclass
 from services.ai_client import AIClient
-import json
 
 
 @dataclass
 class ChatRole:
     """对话角色"""
     name: str
-    persona: str  # 角色人设
-    speaking_style: str  # 说话风格
-    position: str  # 对某话题的立场/观点倾向
+    persona: str          # 角色人设
+    speaking_style: str   # 说话风格
+    position: str         # 对某话题的立场/观点倾向
 
 
 # 预设角色模板
@@ -25,59 +24,52 @@ ROLE_TEMPLATES = {
         name="小阳",
         persona="一个积极乐观的人，总是看到事物好的一面",
         speaking_style="热情、鼓励性的语气，喜欢用正面词汇",
-        position="支持、积极看待"
+        position="支持、积极看待",
     ),
     "现实主义者": ChatRole(
         name="老陈",
         persona="一个务实理性的人，注重分析实际情况",
         speaking_style="冷静、客观的语气，喜欢用数据和事实",
-        position="中立分析、权衡利弊"
+        position="中立分析、权衡利弊",
     ),
     "怀疑论者": ChatRole(
         name="阿疑",
         persona="一个善于质疑的人，总是会提出不同看法",
         speaking_style="谨慎、批判性的语气，喜欢用反问",
-        position="质疑、提出潜在问题"
+        position="质疑、提出潜在问题",
     ),
     "创意者": ChatRole(
         name="小创",
         persona="一个富有想象力的人，总能提出新奇想法",
         speaking_style="活泼、跳跃性的思维，喜欢用比喻",
-        position="创新、发散思考"
+        position="创新、发散思考",
     ),
     "实践者": ChatRole(
         name="老王",
         persona="一个注重实践的人，关心如何落地执行",
         speaking_style="直接、具体的语气，喜欢讲实际案例",
-        position="关注可行性、执行细节"
+        position="关注可行性、执行细节",
     ),
     "哲学家": ChatRole(
         name="孔思",
         persona="一个善于思考的人，喜欢探讨深层含义",
         speaking_style="深沉、思辨的语气，喜欢引用名言",
-        position="追问本质、探索意义"
+        position="追问本质、探索意义",
     ),
 }
 
 
 class DualChatService:
     """双角色对话服务"""
-    
-    def __init__(
-        self,
-        ai_client: AIClient,
-        role_a: ChatRole,
-        role_b: ChatRole,
-        topic: str
-    ):
+
+    def __init__(self, ai_client: AIClient, role_a: ChatRole, role_b: ChatRole, topic: str):
         self.ai_client = ai_client
         self.role_a = role_a
         self.role_b = role_b
         self.topic = topic
         self.conversation_history: List[Dict[str, str]] = []
-    
-    def _build_role_prompt(self, role: ChatRole, is_initiator: bool = False) -> str:
-        """构建角色系统提示"""
+
+    def _build_role_prompt(self, role: ChatRole) -> str:
         return f"""你正在扮演一个名叫"{role.name}"的角色进行对话。
 
 【角色设定】
@@ -96,22 +88,13 @@ class DualChatService:
 5. 不要说"作为{role.name}"这样的元描述
 6. 可以提问、分享观点、表达情感
 """
-    
-    def _build_response_prompt(
-        self, 
-        role: ChatRole, 
-        last_message: str,
-        speaker_name: str
-    ) -> str:
-        """构建回复提示"""
+
+    def _build_response_prompt(self, role: ChatRole, last_message: str, speaker_name: str) -> str:
         history_text = ""
         if self.conversation_history:
-            recent = self.conversation_history[-6:]  # 最近6条
-            history_text = "\n".join([
-                f"{msg['speaker']}: {msg['content']}"
-                for msg in recent
-            ])
-        
+            recent = self.conversation_history[-6:]
+            history_text = "\n".join([f"{msg['speaker']}: {msg['content']}" for msg in recent])
+
         return f"""【对话历史】
 {history_text if history_text else "(对话刚开始)"}
 
@@ -119,110 +102,60 @@ class DualChatService:
 {last_message}
 
 请以"{role.name}"的身份回复，继续这个对话。直接输出你的回复内容，不要包含角色名称前缀。"""
-    
-    def get_opening(self) -> Dict[str, Any]:
+
+    async def get_opening(self) -> Dict:
         """获取开场白"""
         prompt = f"""请以"{self.role_a.name}"的身份，针对话题"{self.topic}"发起对话。
 用一两句话自然地开始聊天，可以分享你对这个话题的看法或提一个问题。
 直接输出对话内容，不要包含角色名称前缀。"""
-        
+
         messages = [
-            {"role": "system", "content": self._build_role_prompt(self.role_a, is_initiator=True)},
-            {"role": "user", "content": prompt}
+            {"role": "system", "content": self._build_role_prompt(self.role_a)},
+            {"role": "user", "content": prompt},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.9)
-        
-        self.conversation_history.append({
-            "speaker": self.role_a.name,
-            "role_id": "a",
-            "content": response
-        })
-        
-        return {
-            "speaker": self.role_a.name,
-            "role_id": "a",
-            "content": response,
-            "turn": 1
-        }
-    
-    def get_response(self, responding_role: str = "b") -> Dict[str, Any]:
-        """获取回复
-        
-        Args:
-            responding_role: "a" 或 "b"，表示哪个角色回复
-        """
+        response = await self.ai_client.get_completion(messages, temperature=0.9)
+        self.conversation_history.append({"speaker": self.role_a.name, "role_id": "a", "content": response})
+        return {"speaker": self.role_a.name, "role_id": "a", "content": response, "turn": 1}
+
+    async def get_response(self, responding_role: str = "b") -> Dict:
+        """获取回复"""
         if not self.conversation_history:
-            return self.get_opening()
-        
+            return await self.get_opening()
+
         role = self.role_b if responding_role == "b" else self.role_a
-        other_role = self.role_a if responding_role == "b" else self.role_b
-        
         last_msg = self.conversation_history[-1]
-        
+
         messages = [
             {"role": "system", "content": self._build_role_prompt(role)},
-            {"role": "user", "content": self._build_response_prompt(
-                role, 
-                last_msg["content"],
-                last_msg["speaker"]
-            )}
+            {"role": "user", "content": self._build_response_prompt(role, last_msg["content"], last_msg["speaker"])},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.9)
-        
-        self.conversation_history.append({
-            "speaker": role.name,
-            "role_id": responding_role,
-            "content": response
-        })
-        
+        response = await self.ai_client.get_completion(messages, temperature=0.9)
+        self.conversation_history.append({"speaker": role.name, "role_id": responding_role, "content": response})
         return {
             "speaker": role.name,
             "role_id": responding_role,
             "content": response,
-            "turn": len(self.conversation_history)
+            "turn": len(self.conversation_history),
         }
-    
-    def stream_response(self, responding_role: str = "b") -> Generator[Dict[str, Any], None, None]:
+
+    async def stream_response(self, responding_role: str = "b") -> AsyncGenerator[Dict, None]:
         """流式获取回复"""
         if not self.conversation_history:
-            # 开场白 - 先发 message 事件，再发 message_complete
-            result = self.get_opening()
-            # 先发送流式消息（即使是完整内容）
-            yield {
-                "type": "message",
-                "speaker": result["speaker"],
-                "role_id": result["role_id"],
-                "content": result["content"],
-                "is_complete": False,
-                "turn": result["turn"]
-            }
-            # 再发送完成事件
-            yield {
-                "type": "message_complete",
-                "speaker": result["speaker"],
-                "role_id": result["role_id"],
-                "content": result["content"],
-                "is_complete": True,
-                "turn": result["turn"]
-            }
+            result = await self.get_opening()
+            yield {"type": "message", "speaker": result["speaker"], "role_id": result["role_id"], "content": result["content"], "is_complete": False, "turn": result["turn"]}
+            yield {"type": "message_complete", "speaker": result["speaker"], "role_id": result["role_id"], "content": result["content"], "is_complete": True, "turn": result["turn"]}
             return
-        
+
         role = self.role_b if responding_role == "b" else self.role_a
         last_msg = self.conversation_history[-1]
-        
+
         messages = [
             {"role": "system", "content": self._build_role_prompt(role)},
-            {"role": "user", "content": self._build_response_prompt(
-                role, 
-                last_msg["content"],
-                last_msg["speaker"]
-            )}
+            {"role": "user", "content": self._build_response_prompt(role, last_msg["content"], last_msg["speaker"])},
         ]
-        
+
         full_response = ""
-        for chunk in self.ai_client.chat_stream(messages, temperature=0.9):
+        async for chunk in self.ai_client.chat_stream(messages, temperature=0.9):
             full_response += chunk
             yield {
                 "type": "message",
@@ -230,64 +163,48 @@ class DualChatService:
                 "role_id": responding_role,
                 "content": full_response,
                 "is_complete": False,
-                "turn": len(self.conversation_history) + 1
+                "turn": len(self.conversation_history) + 1,
             }
-        
-        self.conversation_history.append({
-            "speaker": role.name,
-            "role_id": responding_role,
-            "content": full_response
-        })
-        
+
+        self.conversation_history.append({"speaker": role.name, "role_id": responding_role, "content": full_response})
         yield {
             "type": "message_complete",
             "speaker": role.name,
             "role_id": responding_role,
             "content": full_response,
             "is_complete": True,
-            "turn": len(self.conversation_history)
+            "turn": len(self.conversation_history),
         }
-    
-    def run_conversation(self, turns: int = 6) -> Generator[Dict[str, Any], None, None]:
-        """运行完整对话
-        
-        Args:
-            turns: 对话轮次（每轮包含双方各说一次）
-        """
+
+    async def run_conversation(self, turns: int = 6) -> AsyncGenerator[Dict, None]:
+        """运行完整对话"""
         yield {
             "type": "start",
             "topic": self.topic,
             "role_a": {"name": self.role_a.name, "persona": self.role_a.persona},
             "role_b": {"name": self.role_b.name, "persona": self.role_b.persona},
-            "total_turns": turns
+            "total_turns": turns,
         }
-        
+
         # 角色A开场
-        for event in self.stream_response("a"):
+        async for event in self.stream_response("a"):
             yield event
-        
+
         # 交替对话
         for i in range(turns):
-            # 角色B回复
-            for event in self.stream_response("b"):
+            async for event in self.stream_response("b"):
                 yield event
-            
-            # 角色A回复（除了最后一轮）
             if i < turns - 1:
-                for event in self.stream_response("a"):
+                async for event in self.stream_response("a"):
                     yield event
-        
-        yield {
-            "type": "complete",
-            "total_messages": len(self.conversation_history),
-            "history": self.conversation_history
-        }
-    
-    def get_conversation_summary(self) -> str:
+
+        yield {"type": "complete", "total_messages": len(self.conversation_history), "history": self.conversation_history}
+
+    async def get_conversation_summary(self) -> str:
         """获取对话摘要"""
         if not self.conversation_history:
             return "对话尚未开始"
-        
+
         prompt = f"""请简要总结以下对话的主要内容和观点交锋：
 
 话题：{self.topic}
@@ -296,13 +213,12 @@ class DualChatService:
 {chr(10).join([f"{msg['speaker']}: {msg['content']}" for msg in self.conversation_history])}
 
 请用 2-3 句话概括。"""
-        
+
         messages = [
             {"role": "system", "content": "你是一个善于总结的助手。"},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": prompt},
         ]
-        
-        return self.ai_client.get_completion(messages, temperature=0.5)
+        return await self.ai_client.get_completion(messages, temperature=0.5)
 
 
 def create_dual_chat(
@@ -310,27 +226,10 @@ def create_dual_chat(
     topic: str,
     role_a_template: str = "乐观主义者",
     role_b_template: str = "现实主义者",
-    custom_role_a: Dict[str, str] = None,
-    custom_role_b: Dict[str, str] = None
+    custom_role_a: Optional[Dict[str, str]] = None,
+    custom_role_b: Optional[Dict[str, str]] = None,
 ) -> DualChatService:
-    """创建双角色对话服务
-    
-    Args:
-        ai_client: AI 客户端
-        topic: 对话主题
-        role_a_template: 角色A模板名称
-        role_b_template: 角色B模板名称
-        custom_role_a: 自定义角色A (可选)
-        custom_role_b: 自定义角色B (可选)
-    """
-    if custom_role_a:
-        role_a = ChatRole(**custom_role_a)
-    else:
-        role_a = ROLE_TEMPLATES.get(role_a_template, ROLE_TEMPLATES["乐观主义者"])
-    
-    if custom_role_b:
-        role_b = ChatRole(**custom_role_b)
-    else:
-        role_b = ROLE_TEMPLATES.get(role_b_template, ROLE_TEMPLATES["现实主义者"])
-    
+    """创建双角色对话服务"""
+    role_a = ChatRole(**custom_role_a) if custom_role_a else ROLE_TEMPLATES.get(role_a_template, ROLE_TEMPLATES["乐观主义者"])
+    role_b = ChatRole(**custom_role_b) if custom_role_b else ROLE_TEMPLATES.get(role_b_template, ROLE_TEMPLATES["现实主义者"])
     return DualChatService(ai_client, role_a, role_b, topic)

--- a/backend/services/providers/__init__.py
+++ b/backend/services/providers/__init__.py
@@ -1,0 +1,67 @@
+"""
+AI Provider 工厂
+
+根据 provider 名称创建对应的 Provider 实例。
+"""
+from typing import Optional
+
+from config import get_settings
+from .base import BaseProvider
+from .openai_compat import OpenAICompatProvider
+from .gemini import GeminiProvider
+from .claude import ClaudeProvider
+from .mock import MockProvider
+
+
+def create_provider(
+    provider: str,
+    model: str,
+    api_key: Optional[str] = None,
+    seed: Optional[int] = None,
+) -> BaseProvider:
+    """工厂函数：根据 provider 名称创建对应实例
+
+    Args:
+        provider: 提供商名称（deepseek / openai / gemini / claude / mock）
+        model: 模型名称
+        api_key: API 密钥（可选，优先于环境变量）
+        seed: 随机种子（仅 OpenAI 兼容接口支持）
+
+    Returns:
+        BaseProvider 实例
+    """
+    settings = get_settings()
+
+    if provider == "deepseek":
+        key = api_key or settings.deepseek_api_key
+        return OpenAICompatProvider(
+            api_key=key,
+            base_url=settings.deepseek_api_base,
+            model=model,
+            seed=seed,
+        )
+
+    if provider == "openai":
+        key = api_key or settings.openai_api_key
+        return OpenAICompatProvider(
+            api_key=key,
+            base_url=settings.openai_api_base,
+            model=model,
+            seed=seed,
+        )
+
+    if provider == "gemini":
+        key = api_key or settings.gemini_api_key
+        return GeminiProvider(api_key=key, model=model)
+
+    if provider == "claude":
+        key = api_key or settings.claude_api_key
+        return ClaudeProvider(api_key=key, model=model)
+
+    if provider == "mock":
+        return MockProvider(model=model, seed=seed)
+
+    raise ValueError(f"不支持的提供商: {provider}")
+
+
+__all__ = ["BaseProvider", "create_provider"]

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -1,0 +1,31 @@
+"""
+Provider 抽象基类
+
+定义所有 AI Provider 的统一异步接口。
+"""
+from abc import ABC, abstractmethod
+from typing import AsyncGenerator
+
+
+class BaseProvider(ABC):
+    """AI Provider 抽象基类"""
+
+    @abstractmethod
+    async def get_completion(
+        self,
+        messages: list[dict],
+        temperature: float = 0.7,
+        max_tokens: int = 2000,
+        **kwargs,
+    ) -> str:
+        """获取完整回复（非流式）"""
+
+    @abstractmethod
+    async def chat_stream(
+        self,
+        messages: list[dict],
+        temperature: float = 0.7,
+        max_tokens: int = 2000,
+        **kwargs,
+    ) -> AsyncGenerator[str, None]:
+        """流式获取回复"""

--- a/backend/services/providers/claude.py
+++ b/backend/services/providers/claude.py
@@ -1,0 +1,56 @@
+"""
+Anthropic Claude Provider
+
+使用 anthropic SDK 的异步接口。
+"""
+from typing import AsyncGenerator
+
+from .base import BaseProvider
+
+
+class ClaudeProvider(BaseProvider):
+    """Anthropic Claude Provider"""
+
+    def __init__(self, api_key: str, model: str):
+        import anthropic
+        self.client = anthropic.AsyncAnthropic(api_key=api_key)
+        self.model = model
+
+    def _convert_messages(self, messages: list[dict]) -> tuple[str, list[dict]]:
+        """分离 system prompt 和对话消息"""
+        system_prompt = ""
+        claude_messages = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                system_prompt = content
+            else:
+                claude_messages.append({
+                    "role": "assistant" if role == "assistant" else "user",
+                    "content": content,
+                })
+        return system_prompt, claude_messages
+
+    async def get_completion(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> str:
+        system_prompt, claude_messages = self._convert_messages(messages)
+        response = await self.client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system_prompt,
+            messages=claude_messages,
+        )
+        return response.content[0].text
+
+    async def chat_stream(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> AsyncGenerator[str, None]:
+        system_prompt, claude_messages = self._convert_messages(messages)
+        async with self.client.messages.stream(
+            model=self.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system_prompt,
+            messages=claude_messages,
+        ) as stream:
+            async for text in stream.text_stream:
+                yield text

--- a/backend/services/providers/gemini.py
+++ b/backend/services/providers/gemini.py
@@ -1,0 +1,83 @@
+"""
+Google Gemini Provider
+
+使用 google-genai SDK 的异步接口，并正确转换多轮消息格式。
+"""
+from typing import AsyncGenerator
+
+from .base import BaseProvider
+
+
+class GeminiProvider(BaseProvider):
+    """Google Gemini Provider"""
+
+    def __init__(self, api_key: str, model: str):
+        self.api_key = api_key
+        self.model = model
+
+    def _convert_messages(self, messages: list[dict]):
+        """将 OpenAI 格式消息转换为 Gemini Contents + system_instruction"""
+        from google.genai import types as genai_types
+
+        system_instruction = ""
+        contents = []
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                system_instruction = content
+            elif role == "assistant":
+                contents.append(
+                    genai_types.Content(
+                        role="model",
+                        parts=[genai_types.Part(text=content)],
+                    )
+                )
+            else:
+                contents.append(
+                    genai_types.Content(
+                        role="user",
+                        parts=[genai_types.Part(text=content)],
+                    )
+                )
+
+        return system_instruction, contents
+
+    def _build_config(self, temperature, max_tokens, system_instruction):
+        from google.genai import types as genai_types
+
+        return genai_types.GenerateContentConfig(
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+            system_instruction=system_instruction or None,
+        )
+
+    async def get_completion(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> str:
+        from google import genai as google_genai
+
+        client = google_genai.Client(api_key=self.api_key)
+        system_instruction, contents = self._convert_messages(messages)
+        config = self._build_config(temperature, max_tokens, system_instruction)
+
+        response = await client.aio.models.generate_content(
+            model=self.model,
+            contents=contents,
+            config=config,
+        )
+        return response.text
+
+    async def chat_stream(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> AsyncGenerator[str, None]:
+        from google import genai as google_genai
+
+        client = google_genai.Client(api_key=self.api_key)
+        system_instruction, contents = self._convert_messages(messages)
+        config = self._build_config(temperature, max_tokens, system_instruction)
+
+        async for chunk in await client.aio.models.generate_content_stream(
+            model=self.model,
+            contents=contents,
+            config=config,
+        ):
+            if chunk.text:
+                yield chunk.text

--- a/backend/services/providers/mock.py
+++ b/backend/services/providers/mock.py
@@ -1,0 +1,113 @@
+"""
+Mock Provider
+
+用于测试，生成可复现的确定性响应。
+逻辑从原 AIClient 迁移过来，保持行为不变。
+"""
+import hashlib
+import json
+import random
+from typing import AsyncGenerator, Dict, Optional
+
+from .base import BaseProvider
+
+
+class MockProvider(BaseProvider):
+    """Mock Provider，生成可复现的测试响应"""
+
+    def __init__(self, model: str = "mock", seed: Optional[int] = None):
+        self.model = model
+        self.seed = seed
+
+    def _derive_seed(self, messages: list[dict], temperature: float) -> int:
+        payload = json.dumps(messages, ensure_ascii=False, sort_keys=True)
+        seed_base = self.seed if self.seed is not None else 0
+        raw = f"{seed_base}|{temperature}|{self.model}|{payload}"
+        digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return int(digest[:8], 16)
+
+    def _mock_response(self, messages: list[dict], temperature: float = 0.7) -> str:
+        seed = self._derive_seed(messages, temperature)
+        rng = random.Random(seed)
+        prompt = messages[-1].get("content", "") if messages else ""
+        prompt_str = prompt if isinstance(prompt, str) else json.dumps(prompt, ensure_ascii=False)
+
+        if "pro_score" in prompt_str and "con_score" in prompt_str:
+            return json.dumps(self._mock_round_evaluation(rng), ensure_ascii=False)
+        if "opening_strategy" in prompt_str and "key_arguments" in prompt_str:
+            return json.dumps(self._mock_opening_analysis(rng), ensure_ascii=False)
+        if "selected_strategy" in prompt_str and "counter_points" in prompt_str:
+            return json.dumps(self._mock_counter_analysis(rng), ensure_ascii=False)
+        if "key_turning_points" in prompt_str and "winner" in prompt_str:
+            return json.dumps(self._mock_final_verdict(rng), ensure_ascii=False)
+        return self._mock_argument_text(rng)
+
+    def _mock_opening_analysis(self, rng: random.Random) -> Dict:
+        return {
+            "topic_analysis": "辩题涉及社会与技术变迁的边界，需要区分岗位替代与能力增强。",
+            "core_stance": "技术将改变岗位形态而非完全替代人类价值。",
+            "opening_strategy": "强调历史类比与人机协作的现实案例。",
+            "key_arguments": ["技术替代的是任务而非整体职业", "协作模式会创造新岗位需求", "制度与教育会同步调整"],
+            "anticipated_opposition": ["自动化会导致大规模失业", "AI 成本低于人力"],
+            "confidence": round(rng.uniform(0.6, 0.85), 2),
+        }
+
+    def _mock_counter_analysis(self, rng: random.Random) -> Dict:
+        return {
+            "opponent_main_points": ["对方强调成本优势与效率提升"],
+            "opponent_weaknesses": ["忽视再就业与产业结构调整的时间窗"],
+            "selected_strategy": rng.choice(["direct_refute", "reframe", "counter_example"]),
+            "strategy_reason": "选择可直接削弱对方核心假设的策略。",
+            "counter_points": ["效率提升不等同于岗位消失", "历史上技术升级带来新需求"],
+            "new_arguments": ["政策与教育可缓冲冲击"],
+            "confidence": round(rng.uniform(0.55, 0.8), 2),
+        }
+
+    def _mock_round_evaluation(self, rng: random.Random) -> Dict:
+        def score():
+            return {"logic": rng.randint(5, 9), "evidence": rng.randint(5, 9), "rhetoric": rng.randint(5, 9), "rebuttal": rng.randint(5, 9)}
+
+        pro_score = score()
+        con_score = score()
+        pro_total = sum(pro_score.values())
+        con_total = sum(con_score.values())
+        winner = "pro" if pro_total > con_total else ("con" if con_total > pro_total else "tie")
+        return {
+            "pro_score": pro_score,
+            "con_score": con_score,
+            "round_winner": winner,
+            "commentary": "双方论点清晰，正方在结构性分析上略胜一筹。",
+            "highlights": ["结构化论证", "反驳切中要点"],
+            "suggestions": {"pro": ["补充更多现实案例支撑论点"], "con": ["加强对反例的处理"]},
+        }
+
+    def _mock_final_verdict(self, rng: random.Random) -> Dict:
+        winner = rng.choice(["pro", "con", "tie"])
+        return {
+            "winner": winner,
+            "pro_total_score": rng.randint(60, 75),
+            "con_total_score": rng.randint(58, 74),
+            "margin": rng.choice(["decisive", "close", "marginal"]),
+            "summary": "整体而言，双方论证充分，胜负取决于对关键假设的把握。",
+            "pro_strengths": ["逻辑连贯", "结构完整"],
+            "con_strengths": ["反驳直接", "案例贴近现实"],
+            "key_turning_points": ["第二轮反驳质量差异", "总结陈词的结构性优势"],
+        }
+
+    def _mock_argument_text(self, rng: random.Random) -> str:
+        templates = [
+            "我们需要区分任务替代与职业替代。技术会提升效率，但更重要的是重构分工。",
+            "历史上每次技术革命都会淘汰部分岗位，但也会催生新的价值链。",
+            "关键不在于是否替代，而在于社会如何调整制度与教育以吸收冲击。",
+        ]
+        rng.shuffle(templates)
+        return " ".join(templates)
+
+    async def get_completion(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> str:
+        return self._mock_response(messages, temperature=temperature)
+
+    async def chat_stream(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> AsyncGenerator[str, None]:
+        content = self._mock_response(messages, temperature=temperature)
+        chunk_size = 24
+        for i in range(0, len(content), chunk_size):
+            yield content[i : i + chunk_size]

--- a/backend/services/providers/openai_compat.py
+++ b/backend/services/providers/openai_compat.py
@@ -1,0 +1,74 @@
+"""
+OpenAI 兼容 Provider（适用于 DeepSeek 和 OpenAI）
+
+使用 AsyncOpenAI 客户端，支持连接池复用。
+"""
+from typing import AsyncGenerator, Dict, Optional
+import httpx
+from openai import AsyncOpenAI
+
+from .base import BaseProvider
+
+
+class OpenAICompatProvider(BaseProvider):
+    """OpenAI 兼容 API Provider（DeepSeek / OpenAI）
+
+    类级别连接池，相同配置复用同一 AsyncOpenAI 实例。
+    """
+
+    _client_pool: Dict[str, AsyncOpenAI] = {}
+
+    @classmethod
+    def _get_or_create_client(
+        cls,
+        pool_key: str,
+        api_key: str,
+        base_url: str,
+        timeout: httpx.Timeout,
+    ) -> AsyncOpenAI:
+        if pool_key not in cls._client_pool:
+            cls._client_pool[pool_key] = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=timeout,
+            )
+        return cls._client_pool[pool_key]
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        model: str,
+        seed: Optional[int] = None,
+    ):
+        self.model = model
+        self.seed = seed
+        timeout = httpx.Timeout(connect=5.0, read=60.0, write=10.0, pool=10.0)
+        pool_key = f"{api_key[:8]}:{base_url}"
+        self.client = self._get_or_create_client(pool_key, api_key, base_url, timeout)
+
+    def _build_payload(self, messages, temperature, max_tokens, stream=False) -> dict:
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": stream,
+        }
+        if self.seed is not None:
+            payload["seed"] = self.seed
+        return payload
+
+    async def get_completion(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> str:
+        response = await self.client.chat.completions.create(
+            **self._build_payload(messages, temperature, max_tokens, stream=False)
+        )
+        return response.choices[0].message.content
+
+    async def chat_stream(self, messages, temperature=0.7, max_tokens=2000, **kwargs) -> AsyncGenerator[str, None]:
+        stream = await self.client.chat.completions.create(
+            **self._build_payload(messages, temperature, max_tokens, stream=True)
+        )
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content

--- a/backend/services/socratic_qa.py
+++ b/backend/services/socratic_qa.py
@@ -5,69 +5,53 @@
 同时提供结构化的知识输出。
 """
 
-from typing import Dict, Any, List, Optional, Generator
-from dataclasses import dataclass, field
-from services.ai_client import AIClient
 import json
+from dataclasses import dataclass, field
+from typing import AsyncGenerator, Dict, Any, List
+
+from services.ai_client import AIClient
 
 
 @dataclass
 class SocraticResponse:
     """苏格拉底式回复"""
-    # 引导性问题
     guiding_questions: List[str] = field(default_factory=list)
-    # 启发性提示
     hints: List[str] = field(default_factory=list)
-    # 核心概念解释（简短）
     core_explanation: str = ""
-    # 思考框架
     thinking_framework: str = ""
-    # 相关概念
     related_concepts: List[str] = field(default_factory=list)
-    # 深入探索方向
     explore_further: List[str] = field(default_factory=list)
-    # 难度评估
-    difficulty: str = "intermediate"  # beginner/intermediate/advanced
+    difficulty: str = "intermediate"
 
 
 @dataclass
 class StructuredAnswer:
     """结构化回答"""
-    # 一句话答案
     short_answer: str = ""
-    # 详细解释
     detailed_explanation: str = ""
-    # 核心要点
     key_points: List[str] = field(default_factory=list)
-    # 实际例子
     examples: List[str] = field(default_factory=list)
-    # 常见误区
     common_misconceptions: List[str] = field(default_factory=list)
-    # 相关领域
     related_topics: List[str] = field(default_factory=list)
-    # 延伸阅读建议
     further_reading: List[str] = field(default_factory=list)
-    # 难度
     difficulty: str = "intermediate"
 
 
 class SocraticQAService:
     """苏格拉底式问答服务"""
-    
-    # 模式设置
-    MODE_SOCRATIC = "socratic"  # 引导式
-    MODE_STRUCTURED = "structured"  # 结构化
-    MODE_HYBRID = "hybrid"  # 混合模式
-    
+
+    MODE_SOCRATIC = "socratic"
+    MODE_STRUCTURED = "structured"
+    MODE_HYBRID = "hybrid"
+
     def __init__(self, ai_client: AIClient, mode: str = "hybrid"):
         self.ai_client = ai_client
         self.mode = mode
         self.conversation_history: List[Dict[str, str]] = []
         self.current_topic: str = ""
-        self.understanding_level: int = 0  # 用户理解程度 0-100
-    
+        self.understanding_level: int = 0
+
     def _build_socratic_prompt(self, question: str) -> str:
-        """构建苏格拉底式提问的提示"""
         history_context = ""
         if self.conversation_history:
             recent = self.conversation_history[-4:]
@@ -75,7 +59,7 @@ class SocraticQAService:
                 f"{'用户' if msg['role'] == 'user' else 'AI'}: {msg['content']}"
                 for msg in recent
             ])
-        
+
         return f"""你是一位苏格拉底式的导师，通过提问引导学生思考，而不是直接给出答案。
 
 【用户问题】
@@ -109,7 +93,6 @@ class SocraticQAService:
 ```"""
 
     def _build_structured_prompt(self, question: str) -> str:
-        """构建结构化回答的提示"""
         return f"""请对以下问题给出结构化的回答。
 
 【问题】
@@ -140,9 +123,7 @@ class SocraticQAService:
 ```"""
 
     def _parse_json_response(self, response: str, default: Dict) -> Dict:
-        """解析 JSON 响应"""
         try:
-            # 尝试提取 JSON
             if "```json" in response:
                 start = response.find("```json") + 7
                 end = response.find("```", start)
@@ -157,70 +138,49 @@ class SocraticQAService:
                 json_str = response[start:end]
             else:
                 return default
-            
             return json.loads(json_str)
         except (json.JSONDecodeError, ValueError, TypeError):
             return default
 
-    def ask_socratic(self, question: str) -> Dict[str, Any]:
+    async def ask_socratic(self, question: str) -> Dict[str, Any]:
         """苏格拉底式提问"""
-        prompt = self._build_socratic_prompt(question)
-        
         messages = [
             {"role": "system", "content": "你是一位善于启发思考的苏格拉底式导师。"},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": self._build_socratic_prompt(question)},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.7)
-        
+        response = await self.ai_client.get_completion(messages, temperature=0.7)
         result = self._parse_json_response(response, {
             "opening_remark": "这是个很好的问题！让我们一起思考。",
             "guiding_questions": ["你觉得这个概念的核心是什么？"],
             "hints": ["试着从基础定义开始思考"],
             "thinking_framework": "可以从 What-Why-How 的角度思考",
-            "encouragement": "相信你通过思考一定能理解！"
+            "encouragement": "相信你通过思考一定能理解！",
         })
-        
-        # 记录历史
         self.conversation_history.append({"role": "user", "content": question})
         self.conversation_history.append({
-            "role": "assistant", 
-            "content": result.get("opening_remark", "") + "\n" + "\n".join(result.get("guiding_questions", []))
+            "role": "assistant",
+            "content": result.get("opening_remark", "") + "\n" + "\n".join(result.get("guiding_questions", [])),
         })
-        
-        return {
-            "type": "socratic",
-            "question": question,
-            **result
-        }
+        return {"type": "socratic", "question": question, **result}
 
-    def ask_structured(self, question: str) -> Dict[str, Any]:
+    async def ask_structured(self, question: str) -> Dict[str, Any]:
         """结构化问答"""
-        prompt = self._build_structured_prompt(question)
-        
         messages = [
             {"role": "system", "content": "你是一位知识渊博的专家，善于给出结构清晰的回答。"},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": self._build_structured_prompt(question)},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.5)
-        
+        response = await self.ai_client.get_completion(messages, temperature=0.5)
         result = self._parse_json_response(response, {
             "short_answer": "暂无简短回答",
             "detailed_explanation": response,
             "key_points": [],
             "examples": [],
             "related_topics": [],
-            "difficulty": "intermediate"
+            "difficulty": "intermediate",
         })
-        
-        return {
-            "type": "structured",
-            "question": question,
-            **result
-        }
+        return {"type": "structured", "question": question, **result}
 
-    def ask_hybrid(self, question: str) -> Dict[str, Any]:
+    async def ask_hybrid(self, question: str) -> Dict[str, Any]:
         """混合模式：先引导思考，再给结构化答案"""
         prompt = f"""请对以下问题进行苏格拉底式引导 + 结构化回答的混合回复。
 
@@ -245,40 +205,32 @@ class SocraticQAService:
     "learning_path": "建议的学习路径"
 }}
 ```"""
-        
+
         messages = [
             {"role": "system", "content": "你既是苏格拉底式导师，也是知识专家。"},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": prompt},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.6)
-        
+        response = await self.ai_client.get_completion(messages, temperature=0.6)
         result = self._parse_json_response(response, {
             "socratic_part": {"opening": "让我们一起思考这个问题", "questions": [], "hints": []},
             "structured_part": {"short_answer": "", "key_points": [], "example": "", "related": []},
             "difficulty": "intermediate",
-            "learning_path": ""
+            "learning_path": "",
         })
-        
-        return {
-            "type": "hybrid",
-            "question": question,
-            **result
-        }
+        return {"type": "hybrid", "question": question, **result}
 
-    def ask(self, question: str) -> Dict[str, Any]:
+    async def ask(self, question: str) -> Dict[str, Any]:
         """根据模式回答问题"""
         if self.mode == self.MODE_SOCRATIC:
-            return self.ask_socratic(question)
-        elif self.mode == self.MODE_STRUCTURED:
-            return self.ask_structured(question)
-        else:
-            return self.ask_hybrid(question)
+            return await self.ask_socratic(question)
+        if self.mode == self.MODE_STRUCTURED:
+            return await self.ask_structured(question)
+        return await self.ask_hybrid(question)
 
-    def stream_ask(self, question: str) -> Generator[Dict[str, Any], None, None]:
+    async def stream_ask(self, question: str) -> AsyncGenerator[Dict[str, Any], None]:
         """流式问答（用于实时显示）"""
         yield {"type": "thinking", "content": "正在分析问题..."}
-        
+
         if self.mode == self.MODE_SOCRATIC:
             prompt = self._build_socratic_prompt(question)
             system = "你是一位善于启发思考的苏格拉底式导师。请直接用自然语言引导用户思考，不要输出JSON。先提出引导性问题，再给一些提示。"
@@ -293,38 +245,27 @@ class SocraticQAService:
 
 问题：{question}"""
             system = "你既善于启发思考，也善于系统讲解。"
-        
+
         messages = [
             {"role": "system", "content": system},
-            {"role": "user", "content": prompt}
+            {"role": "user", "content": prompt},
         ]
-        
+
         full_response = ""
-        for chunk in self.ai_client.chat_stream(messages, temperature=0.7):
+        async for chunk in self.ai_client.chat_stream(messages, temperature=0.7):
             full_response += chunk
-            yield {
-                "type": "content",
-                "content": full_response,
-                "is_complete": False
-            }
-        
-        # 记录历史
+            yield {"type": "content", "content": full_response, "is_complete": False}
+
         self.conversation_history.append({"role": "user", "content": question})
         self.conversation_history.append({"role": "assistant", "content": full_response})
-        
-        yield {
-            "type": "complete",
-            "content": full_response,
-            "is_complete": True,
-            "mode": self.mode
-        }
 
-    def follow_up(self, user_response: str) -> Dict[str, Any]:
+        yield {"type": "complete", "content": full_response, "is_complete": True, "mode": self.mode}
+
+    async def follow_up(self, user_response: str) -> Dict[str, Any]:
         """处理用户的思考回复"""
         if not self.conversation_history:
-            return self.ask(user_response)
-        
-        # 分析用户的理解程度
+            return await self.ask(user_response)
+
         analyze_prompt = f"""用户在回答引导问题后说："{user_response}"
 
 之前的对话：
@@ -344,37 +285,26 @@ class SocraticQAService:
     "content": "具体的回复内容（引导问题或解释）"
 }}
 ```"""
-        
+
         messages = [
             {"role": "system", "content": "你是一位耐心的苏格拉底式导师。"},
-            {"role": "user", "content": analyze_prompt}
+            {"role": "user", "content": analyze_prompt},
         ]
-        
-        response = self.ai_client.get_completion(messages, temperature=0.6)
+        response = await self.ai_client.get_completion(messages, temperature=0.6)
         result = self._parse_json_response(response, {
             "understanding_level": 50,
             "feedback": "让我们继续思考",
             "next_step": "continueGuiding",
-            "content": "能再详细说说你的想法吗？"
+            "content": "能再详细说说你的想法吗？",
         })
-        
+
         self.understanding_level = result.get("understanding_level", 50)
-        
-        # 记录
         self.conversation_history.append({"role": "user", "content": user_response})
         self.conversation_history.append({"role": "assistant", "content": result.get("content", "")})
-        
-        return {
-            "type": "follow_up",
-            **result
-        }
+
+        return {"type": "follow_up", **result}
 
 
-def create_socratic_qa(
-    ai_client: AIClient,
-    mode: str = "hybrid"
-) -> SocraticQAService:
+def create_socratic_qa(ai_client: AIClient, mode: str = "hybrid") -> SocraticQAService:
     """创建苏格拉底问答服务"""
     return SocraticQAService(ai_client, mode)
-
-

--- a/frontend/src/hooks/useSSEStream.ts
+++ b/frontend/src/hooks/useSSEStream.ts
@@ -1,0 +1,103 @@
+import { useCallback, useRef, useState } from 'react'
+
+interface SSEStreamState {
+    isStreaming: boolean
+    error: string | null
+}
+
+interface UseSSEStreamReturn {
+    isStreaming: boolean
+    error: string | null
+    start: (url: string, onEvent: (event: unknown) => void) => Promise<void>
+    stop: () => void
+}
+
+/**
+ * 通用 SSE 流式请求 Hook
+ *
+ * 封装了：
+ * - 流式连接的生命周期管理（开始/停止）
+ * - isStreaming / error 状态
+ * - AbortController 取消支持
+ *
+ * 用法：
+ *   const { isStreaming, error, start, stop } = useSSEStream()
+ *   await start(url, (event) => { ... })
+ */
+export function useSSEStream(): UseSSEStreamReturn {
+    const [state, setState] = useState<SSEStreamState>({ isStreaming: false, error: null })
+    const abortRef = useRef<AbortController | null>(null)
+
+    const stop = useCallback(() => {
+        abortRef.current?.abort()
+        abortRef.current = null
+        setState({ isStreaming: false, error: null })
+    }, [])
+
+    const start = useCallback(async (url: string, onEvent: (event: unknown) => void): Promise<void> => {
+        // 终止已有连接
+        abortRef.current?.abort()
+
+        const controller = new AbortController()
+        abortRef.current = controller
+
+        setState({ isStreaming: true, error: null })
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: { Accept: 'text/event-stream' },
+                signal: controller.signal,
+            })
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`)
+            }
+
+            const reader = response.body?.getReader()
+            if (!reader) throw new Error('No response body')
+
+            const decoder = new TextDecoder()
+            let buffer = ''
+
+            while (true) {
+                const { done, value } = await reader.read()
+                if (done) break
+
+                buffer += decoder.decode(value, { stream: true })
+                const lines = buffer.split('\n')
+                buffer = lines.pop() ?? ''
+
+                for (const rawLine of lines) {
+                    const line = rawLine.trim()
+                    if (!line.startsWith('data:')) continue
+
+                    const payload = line.slice(5).trim()
+                    if (!payload || payload === '[DONE]') continue
+
+                    try {
+                        onEvent(JSON.parse(payload))
+                    } catch {
+                        console.error('Failed to parse SSE data:', payload)
+                    }
+                }
+            }
+
+            setState({ isStreaming: false, error: null })
+        } catch (err) {
+            if ((err as Error).name === 'AbortError') {
+                // 用户主动取消，不视为错误
+                setState({ isStreaming: false, error: null })
+                return
+            }
+            const message = err instanceof Error ? err.message : String(err)
+            setState({ isStreaming: false, error: message })
+        } finally {
+            if (abortRef.current === controller) {
+                abortRef.current = null
+            }
+        }
+    }, [])
+
+    return { isStreaming: state.isStreaming, error: state.error, start, stop }
+}


### PR DESCRIPTION
## Summary
This PR refactors the AI client layer from a synchronous, monolithic design to an async-first provider pattern using strategy architecture. All AI operations are now fully asynchronous to prevent blocking the FastAPI event loop.

## Key Changes

### Core Architecture
- **Removed inheritance**: `DebateOrchestrator` no longer inherits from `BaseAgent`, becoming a standalone coordinator class
- **Provider pattern**: Introduced `BaseProvider` abstract class with concrete implementations for each AI service (OpenAI-compatible, Gemini, Claude, Mock)
- **Factory pattern**: Added `create_provider()` factory function in `services/providers/__init__.py` for provider instantiation
- **Async-first**: All AI operations converted to async/await with `AsyncOpenAI` and provider-specific async SDKs

### New Provider Implementations
- **OpenAICompatProvider**: Unified handler for DeepSeek and OpenAI with connection pooling via `AsyncOpenAI`
- **GeminiProvider**: Google Gemini support with proper message format conversion
- **ClaudeProvider**: Anthropic Claude with async client and system prompt separation
- **MockProvider**: Deterministic test responses with seed-based reproducibility

### API Changes
- `AIClient.get_completion()` → `async def get_completion()` (now awaitable)
- `AIClient.chat_stream()` → `async def chat_stream()` (returns `AsyncGenerator`)
- Removed synchronous `chat()` method entirely
- All router endpoints updated to `async def` with `await` calls

### Service Layer Updates
- **DualChatService**: Methods converted to async (`get_opening()`, `get_response()`)
- **SocraticQAService**: Methods converted to async (`ask_socratic()`, `ask_structured()`)
- **DebateOrchestrator**: Simplified initialization, removed `think()` and `act()` methods, added `add_to_memory()` helper

### Frontend
- Added `useSSEStream()` hook for unified SSE stream handling with AbortController support

## Implementation Details
- Connection pooling maintained at `OpenAICompatProvider` class level to reuse `AsyncOpenAI` instances
- Message format conversion centralized in each provider (Gemini, Claude) to handle API-specific requirements
- Mock provider uses deterministic seeding for reproducible test responses
- All router endpoints (`/chat/stream`, `/qa/stream`, `/debate/agent`) updated to async generators
- Removed redundant docstrings and comments for cleaner code

https://claude.ai/code/session_01XkgsnUSbR3bDP8at3buBJW