### PR TITLE
fix: skip non-debater messages in debate graph generation

### DIFF
--- a/backend/routers/debate/graph.py
+++ b/backend/routers/debate/graph.py
@@ -14,6 +14,12 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter()
+ROLE_TO_AUTHOR = {
+    "正方": "pro",
+    "反方": "con",
+    "pro": "pro",
+    "con": "con",
+}
 
 
 @router.get("/debate/{session_id}/graph")
@@ -51,9 +57,11 @@ async def get_argument_graph(
         # 构建图谱
         graph = ArgumentGraph(topic=session.topic or "")
         
-        # 添加论点节点
+        # 添加论点节点（仅保留辩手消息，跳过 user/assistant/system 等）
         for msg in messages:
-            author = "pro" if msg.role == "正方" else "con"
+            author = ROLE_TO_AUTHOR.get(msg.role or "")
+            if not author:
+                continue
             round_num = msg.meta_info.get("round", 1) if msg.meta_info else 1
             
             # 简单的关键点提取
@@ -75,6 +83,9 @@ async def get_argument_graph(
                 key_points=key_points,
                 strength=strength
             )
+
+        if not graph.nodes:
+            return {"error": "No debater messages in session"}
         
         # 简单的关系推断
         node_list = list(graph.nodes.values())

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -70,6 +70,45 @@ class TestHistoryAPI:
         assert socratic_data["history"][0]["type"] == "qa_socratic"
 
 
+class TestDebateGraphAPI:
+    """测试辩论图谱 API"""
+
+    def test_graph_ignores_non_debater_messages(self, client, db_session):
+        from models.session import Session, Message
+
+        session = Session(session_type="debate", topic="测试图谱")
+        db_session.add(session)
+        db_session.flush()
+        db_session.add_all([
+            Message(session_id=session.id, role="user", content="用户提问"),
+            Message(session_id=session.id, role="assistant", content="系统说明"),
+            Message(session_id=session.id, role="正方", content="正方观点"),
+            Message(session_id=session.id, role="反方", content="反方观点"),
+        ])
+        db_session.commit()
+
+        response = client.get(f"/api/debate/{session.id}/graph")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scores"]["total_arguments"] == 2
+
+    def test_graph_returns_error_when_no_debater_messages(self, client, db_session):
+        from models.session import Session, Message
+
+        session = Session(session_type="debate", topic="无辩手消息")
+        db_session.add(session)
+        db_session.flush()
+        db_session.add_all([
+            Message(session_id=session.id, role="user", content="只有用户消息"),
+            Message(session_id=session.id, role="assistant", content="只有助手消息"),
+        ])
+        db_session.commit()
+
+        response = client.get(f"/api/debate/{session.id}/graph")
+        assert response.status_code == 200
+        assert response.json() == {"error": "No debater messages in session"}
+
+
 # 注意：以下测试需要 AI API Key，CI 中可能跳过
 class TestDebateAPI:
     """测试辩论 API（需要 mock 或真实 API Key）"""


### PR DESCRIPTION
### Motivation
- Fix incorrect behavior where any non-`正方` role was treated as `con`, causing `user`/`assistant` messages to be counted as debate arguments.
- Prevent generation of misleading graph/score output for sessions that contain messages but no debater (正方/反方) utterances.
- Make debate graph construction explicit and robust so frontend analysis and visualization rely only on debater messages.

### Description
- Add a `ROLE_TO_AUTHOR` mapping and use it to map roles (`"正方"/"反方"/"pro"/"con"`) to authors and skip unrelated roles. 
- Skip non-debater messages when building the `ArgumentGraph` and return `{"error": "No debater messages in session"}` when no debater nodes were added. 
- Add API tests in `backend/tests/test_api.py` to verify that non-debater messages are ignored and that sessions with only non-debater messages return the expected error.

### Testing
- Ran targeted tests with `cd backend && pytest -q tests/test_api.py::TestDebateGraphAPI tests/test_api.py::TestHistoryAPI::test_get_history_empty`, and they passed (`3 passed`).
- Ran the full backend test suite with `cd backend && pytest -q`, and it passed (`67 passed, 1 skipped`).
- All modified and new tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea058882e88322b146ecdc051fa540)